### PR TITLE
Update parameter order for posting new activity

### DIFF
--- a/src/main/java/travel/controller/ActivityController.java
+++ b/src/main/java/travel/controller/ActivityController.java
@@ -52,7 +52,7 @@ public class ActivityController {
 	 * @return activities
 	 */
 	@PostMapping("/newActivity")
-	public String saveActivity(@Valid @ModelAttribute("newActivity") Activity activity, @PathVariable("id") int id, BindingResult bindingResult, Model model) {
+	public String saveActivity(@PathVariable("id") int id, @Valid @ModelAttribute("newActivity") Activity activity, BindingResult bindingResult, Model model) {
 		if (bindingResult.hasErrors()) {
 			model.addAttribute("newActivity", activity);
 			return "creatingActivity";


### PR DESCRIPTION
Updating the  parameters for the `POST` mapping allowed the binding result to catch and display errors with the user input when creating an activity.